### PR TITLE
chore(dev): robustify portless dev scripts + add Conductor settings

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,15 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+# Installs portless (the reverse proxy used by the parallel-dev stack). The
+# frontend's own dependencies are installed lazily by dev.sh on first run.
+setup = "npm --prefix scripts install"
+# Brings up the branch-isolated Compose stack (Postgres + Keycloak) and starts
+# all backends + the Vite frontend, routed via portless.
+run = "npm --prefix scripts run dev"
+# Tears down this branch's Compose containers when the workspace is archived.
+archive = "npm --prefix scripts run dev:down"
+# Safe to run several workspaces at once: dev-env.sh derives Postgres/Keycloak
+# ports and the Compose project name from the git branch, and portless routes
+# by per-branch hostname on the shared :1355 proxy.
+run_mode = "concurrent"

--- a/scripts/dev-down.sh
+++ b/scripts/dev-down.sh
@@ -12,7 +12,7 @@ source "$SCRIPT_DIR/dev-env.sh"
 
 PORTLESS="$SCRIPT_DIR/node_modules/.bin/portless"
 
-docker compose -f "$REPO_ROOT/stack/docker-compose.yml" down
+docker compose -p "$COMPOSE_PROJECT_NAME" -f "$REPO_ROOT/stack/docker-compose.yml" down --remove-orphans
 
 if [[ -x "$PORTLESS" ]]; then
   "$PORTLESS" alias --remove "auth.${BRANCH_SLUG}" 2>/dev/null || true

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -3,9 +3,14 @@
 # Sourced by dev.sh and dev-down.sh — derives branch-aware values from the
 # current git branch so that two checkouts running this script never collide.
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Honor a REPO_ROOT already set by the caller (dev.sh / dev-down.sh anchor it to
+# the script location under bash). Fall back to git so a standalone `source` of
+# this file still works — relying on ${BASH_SOURCE[0]} breaks when sourced from a
+# non-bash shell (e.g. zsh), yielding an empty BRANCH_SLUG and a wrong project.
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 
 BRANCH_SLUG="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD | tr '/_' '--' | tr '[:upper:]' '[:lower:]')"
+: "${BRANCH_SLUG:?BRANCH_SLUG is empty — not inside a git repository?}"
 HASH="$(echo -n "$BRANCH_SLUG" | cksum | cut -d ' ' -f1)"
 
 export BRANCH_SLUG

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -16,6 +16,14 @@ if [[ ! -x "$PORTLESS" ]]; then
   exit 1
 fi
 
+# Ensure the frontend's dependencies exist — `npm run dev` (vite) fails with
+# "vite: command not found" otherwise. Only install when missing.
+FRONTEND_DIR="$REPO_ROOT/services/shop/shop-frontend"
+if [[ ! -x "$FRONTEND_DIR/node_modules/.bin/vite" ]]; then
+  echo "Installing frontend dependencies (one-time)..."
+  npm --prefix "$FRONTEND_DIR" install
+fi
+
 cat <<EOF
 Starting parallel dev for branch '${BRANCH_SLUG}':
   postgres   localhost:${POSTGRES_PORT}
@@ -35,7 +43,9 @@ docker compose -f "$REPO_ROOT/stack/docker-compose.yml" up -d --wait
 "$PORTLESS" alias "auth.${BRANCH_SLUG}" "${KEYCLOAK_PORT}"
 
 pids=()
-trap 'echo; echo "Shutting down..."; kill "${pids[@]}" 2>/dev/null || true' INT TERM
+# Conductor stops the Run script with SIGHUP (then SIGKILL), so trap it too —
+# otherwise the child Gradle/Vite processes are orphaned on stop.
+trap 'echo; echo "Shutting down..."; kill "${pids[@]}" 2>/dev/null || true' INT TERM HUP
 
 "$PORTLESS" "app.${BRANCH_SLUG}"       npm --prefix "$REPO_ROOT/services/shop/shop-frontend" run dev &
 pids+=($!)


### PR DESCRIPTION
- dev-env.sh: honor caller REPO_ROOT, fall back to git rev-parse; fail fast on empty BRANCH_SLUG
- dev-down.sh: target Compose project explicitly (-p) and --remove-orphans
- dev.sh: install frontend deps on first run; trap SIGHUP so children stop cleanly
- add .conductor/settings.toml (setup/run/archive + concurrent run_mode)