### PR TITLE
feat: Complete Keycloak migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ dist/
 .claude
 
 /.gradle-local/
+.claude/logs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,11 +116,13 @@ src/main/kotlin/
 - Vite build tool
 - Material-UI components
 - TanStack Query for state management
-- Auth0 for authentication
+- Keycloak (OAuth2/OIDC) for authentication
 
 **Infrastructure:**
 
 - Docker containers
+- Docker Compose stack (`stack/`) for local development (Postgres, Keycloak, nginx; optional backend/frontend)
+- Keycloak (self-hosted OAuth2/OIDC, realm config in `stack/keycloak/`)
 - Kubernetes/Helm for deployment
 - Minikube for local development
 

--- a/README.md
+++ b/README.md
@@ -51,99 +51,124 @@ Within this monorepo, we are using a variety of technologies to keep things inte
 
 **Infrastructure Crew:**
 
-- **Auth0** - Authentication that just works™
-- **Docker** - Containerization for the container-curious
+- **Keycloak** - Self-hosted auth, bundled and pre-configured so you don't have to sign up for anything
+- **Docker + Docker Compose** - Containerization for the container-curious
 - **Kubernetes + Helm** - Orchestration without the orchestra pit
 - **Minikube** - Kubernetes for your laptop
 
-## 🚀 Quick Start (Or Not So Quick)
+## 🚀 Quick Start (The Easy Way™)
 
-1. **Fire up the infrastructure** (grab a coffee, this takes a moment):
+The fastest way to get the whole shop running — including a pre-configured **Keycloak** with
+ready-to-use test users — is the bundled Docker Compose stack in [`stack/`](stack/):
+
+```bash
+cd stack
+
+# Just the infrastructure (Postgres, Keycloak, nginx reverse proxy)
+docker compose up -d
+
+# ...or the full shop (infrastructure + backend + frontend)
+docker compose --profile with-shop up -d
+```
+
+Everything is reachable through the nginx reverse proxy on a single port:
+
+| URL | Target |
+|-----|--------|
+| `http://localhost:8080/` | Frontend |
+| `http://localhost:8080/api/` | Backend |
+| `http://localhost:8080/auth/` | Keycloak |
+| `http://localhost:8080/auth/admin` | Keycloak Admin (`admin` / `admin`) |
+
+Log in with one of the bundled test users (realm `retail`, password `test`): `alice`, `bob`
+(both `CUSTOMER`), or `shopkeeper` (`CUSTOMER` + `ADMIN`). See [stack/README.md](stack/README.md)
+for details.
+
+### Running services locally (without Compose)
+
+You can also run the backends/frontend directly while keeping the infrastructure in Compose:
+
+1. **Start the infrastructure** (Postgres + Keycloak + nginx):
    ```bash
-   minikube start
-   kubectl config use-context minikube
-   minikube tunnel # keep the terminal open
-   ```
-   
-2. **Deploy database to minikube**:
-   ```bash
-   cd charts
-   helm dependency build ./postgres
-   helm upgrade --install postgres ./postgres
-   kubectl get po -w # Wait until the database pod is ready
+   cd stack && docker compose up -d
    ```
 
-3. **Build everything** (grab another coffee):
+2. **Build everything**:
    ```bash
    ./gradlew build
    ```
 
-4. Start the services
+3. **Start the services**
+   - **Backends**: run the "retail application" compound config in IntelliJ, or
+     `./gradlew :services:shop:shop-backend:bootRun` (and likewise for delivery/warehouse).
+     The dev profile already points `ISSUER_URI` at the local Keycloak realm
+     (see [application-dev.yml](services/shop/shop-backend/src/main/resources/application-dev.yml)).
+   - **Frontend**: `cd services/shop/shop-frontend && yarn dev`.
+     Local Keycloak settings live in
+     [services/shop/shop-frontend/public/app.env](services/shop/shop-frontend/public/app.env).
 
-   **a) locally**
-   Start "retail application" by running compound config within IntelliJ
+### Running on Minikube (alternative)
 
-   **b) within Minikube** (you know the drill):
-   ```bash
-   # Build all the images
-   minikube image build -t shop-backend:local -f services/shop/shop-backend/Dockerfile .
-   minikube image build -t delivery-backend:local -f services/delivery/delivery-backend/Dockerfile .
-   minikube image build -t warehouse-backend:local -f services/warehouse/warehouse-backend/Dockerfile .
-   minikube image build -t shop-frontend:local -f services/shop/shop-frontend/Dockerfile .
-   
-   # Deploy the shop
-   helm upgrade --install shop-backend ./shop-backend --values ./shop-backend/values.local.yaml
-   ```
+A Helm-based Minikube setup also exists under [`charts/`](charts/):
 
-## 🔐 Auth0 Setup (Account, Client, Users)
+```bash
+minikube start
+kubectl config use-context minikube
+minikube tunnel # keep the terminal open
 
-If you want to run OAuth with your own Auth0 tenant, use this flow:
+cd charts
+helm dependency build ./postgres
+helm upgrade --install postgres ./postgres
+kubectl get po -w # Wait until the database pod is ready
 
-1. Create an Auth0 account and tenant
-   - Go to `https://auth0.com/` and create a free account
-   - Create a tenant (domain looks like `your-tenant.eu.auth0.com` or `your-tenant.us.auth0.com`)
+# Build all the images
+minikube image build -t shop-backend:local -f services/shop/shop-backend/Dockerfile .
+minikube image build -t delivery-backend:local -f services/delivery/delivery-backend/Dockerfile .
+minikube image build -t warehouse-backend:local -f services/warehouse/warehouse-backend/Dockerfile .
+minikube image build -t shop-frontend:local -f services/shop/shop-frontend/Dockerfile .
 
-2. Create an API (optional but recommended)
-   - Auth0 Dashboard -> `Applications` -> `APIs` -> `Create API`
-   - Example:
-     - Name: `Retail API`
-     - Identifier (Audience): `https://retail-ddd-example.api`
-   - Save the API
+# Deploy the shop
+helm upgrade --install shop-backend ./shop-backend --values ./shop-backend/values.local.yaml
+```
 
-3. Create a frontend client (Single Page Application)
-   - Auth0 Dashboard -> `Applications` -> `Applications` -> `Create Application`
-   - Type: `Single Page Application`
-   - In the app settings, configure for local usage:
-     - Allowed Callback URLs: `http://localhost:5173, http://localhost:8080`
-     - Allowed Logout URLs: `http://localhost:5173, http://localhost:8080`
-     - Allowed Web Origins: `http://localhost:5173, http://localhost:8080`
-   - Save and copy:
-     - `Domain` (your tenant domain)
-     - `Client ID`
+**Keycloak** runs in-cluster too, as its own chart
+([charts/infrastructure/keycloak](charts/infrastructure/keycloak)) behind Traefik under `/auth`,
+with the `retail` realm imported by `keycloak-config-cli`. The services are wired to it via the
+`KEYCLOAK_*` ([charts/shop-frontend/values.local.yaml](charts/shop-frontend/values.local.yaml)) and
+`security.issuer-uri` / `security.jwk-set-uri`
+([charts/shop-backend/values.local.yaml](charts/shop-backend/values.local.yaml)) values. The backend
+validates the token `iss` against the browser-facing `issuer-uri` but fetches JWKS from the
+in-cluster `jwk-set-uri` (since the browser URL isn't reachable from inside a pod). See
+[charts/README.md](charts/README.md) for the full Minikube/Traefik walkthrough.
 
-4. Create users
-   - Auth0 Dashboard -> `User Management` -> `Users` -> `Create User`
-   - Use the default database connection (`Username-Password-Authentication`) or your own connection
-   - Ensure this connection is enabled for your SPA application
+## 🔐 Authentication (Keycloak)
 
-5. Wire Auth0 values into this project
-   - Frontend local runtime config:
-     - [services/shop/shop-frontend/public/app.env](services/shop/shop-frontend/public/app.env)
-     - Set:
-       - `OAUTH_ENABLED=true`
-       - `OAUTH_DOMAIN=<your-tenant-domain>`
-       - `OAUTH_CLIENT_ID=<your-client-id>`
-       - `OAUTH_AUDIENCE=<your-api-identifier>` (or empty, depending on your token setup)
-   - Shop backend local issuer:
-     - [services/shop/shop-backend/src/main/resources/application-dev.yml](services/shop/shop-backend/src/main/resources/application-dev.yml)
-     - Set `SECURITY_OAUTH2_ISSUER_URI=https://<your-tenant-domain>/`
+Authentication is handled by a **self-hosted Keycloak** that ships with the Docker Compose stack —
+no external accounts, no sign-up, no secrets to copy around. On startup,
+[keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli) imports the `retail` realm
+from [stack/keycloak/retail-realm.yaml](stack/keycloak/retail-realm.yaml), which defines:
 
-6. Wire Auth0 values for Helm/Minikube
-   - Frontend Helm values:
-     - [charts/shop-frontend/values.local.yaml](charts/shop-frontend/values.local.yaml)
-   - Backend Helm values:
-     - [charts/shop-backend/values.local.yaml](charts/shop-backend/values.local.yaml)
-   - Set the same domain/client/issuer values there before `helm upgrade --install`
+- A public SPA client `shop-frontend`
+- Realm roles `CUSTOMER` and `ADMIN`
+- Three test users (all with password `test`):
+
+  | User | Roles |
+  |------|-------|
+  | `alice` | `CUSTOMER` |
+  | `bob` | `CUSTOMER` |
+  | `shopkeeper` | `CUSTOMER`, `ADMIN` |
+
+How the pieces are wired:
+
+- **Frontend** reads its Keycloak settings at runtime from
+  [services/shop/shop-frontend/public/app.env](services/shop/shop-frontend/public/app.env)
+  (`KEYCLOAK_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID`).
+- **Backend** validates JWTs against the realm via `ISSUER_URI`
+  (`http://localhost:8080/auth/realms/retail`), configured in
+  [application-dev.yml](services/shop/shop-backend/src/main/resources/application-dev.yml).
+
+To inspect or tweak realm settings, open the admin console at
+`http://localhost:8080/auth/admin` (`admin` / `admin`).
 
 ## 🏗️ Architecture: It's Hexagonal, Darling
 

--- a/charts/README.md
+++ b/charts/README.md
@@ -6,6 +6,25 @@ Dieser Setup läuft komplett hinter Traefik. Zugriff erfolgt über:
 - Shop Backend: `http://localhost:8080/api/...`
 - Warehouse Backend: `http://localhost:8080/warehouse/...`
 - Delivery Backend: `http://localhost:8080/delivery/...`
+- Keycloak: `http://localhost:8080/auth/` (Admin-Konsole: `/auth/admin`, `admin` / `admin`)
+
+## Authentifizierung (Keycloak)
+
+Keycloak läuft als eigener Chart **im Cluster** (`infrastructure/keycloak`) hinter Traefik unter
+`/auth`. Der `retail`-Realm wird per `keycloak-config-cli` (Helm post-install Hook) importiert und
+legt die Test-User `alice`, `bob` und `shopkeeper` (Passwort `test`) an.
+
+Die Services sind passend konfiguriert:
+
+- Frontend (`shop-frontend/values.local.yaml`): `env.KEYCLOAK_URL` / `KEYCLOAK_REALM` / `KEYCLOAK_CLIENT_ID`
+- Backend (`shop-backend/values.local.yaml`):
+  - `application.security.issuer-uri` → browser-seitige URL (`http://localhost:8080/auth/realms/retail`),
+    muss mit dem `iss`-Claim der Tokens übereinstimmen.
+  - `application.security.jwk-set-uri` → clusterinterner Service
+    (`http://keycloak:8080/auth/realms/retail/protocol/openid-connect/certs`). Wird als
+    `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI` ins Deployment gemappt, da der
+    browser-seitige `issuer-uri` aus dem Pod heraus nicht erreichbar ist. Die `iss`-Prüfung läuft
+    weiterhin gegen den `issuer-uri`.
 
 ## Prerequisites
 
@@ -35,7 +54,7 @@ minikube -p retail-example image build -t warehouse-backend:local -f services/wa
 minikube -p retail-example image build -t shop-frontend:local -f services/shop/shop-frontend/Dockerfile .
 ```
 
-## 3) Infrastruktur deployen (CNPG Operator -> Postgres -> Traefik)
+## 3) Infrastruktur deployen (CNPG Operator -> Postgres -> Traefik -> Keycloak)
 
 ```bash
 helm dependency build ./infrastructure/cnpg-operator
@@ -56,6 +75,11 @@ helm upgrade --install traefik ./infrastructure/traefik \
   --namespace traefik \
   --create-namespace \
   -f infrastructure/traefik/values.yaml 
+
+# Keycloak (Release-Name "keycloak", damit der Service clusterintern als
+# http://keycloak:8080 erreichbar ist – darauf zeigt die backend jwk-set-uri).
+helm upgrade --install keycloak ./infrastructure/keycloak \
+  --namespace retail-local
 ```
 
 ## 4) Services deployen

--- a/charts/infrastructure/keycloak/Chart.yaml
+++ b/charts/infrastructure/keycloak/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: keycloak
+description: Self-hosted Keycloak (OAuth2/OIDC) with the retail realm imported via keycloak-config-cli
+type: application
+version: 0.1.0
+appVersion: "26.3"

--- a/charts/infrastructure/keycloak/files/retail-realm.yaml
+++ b/charts/infrastructure/keycloak/files/retail-realm.yaml
@@ -1,0 +1,59 @@
+realm: retail
+enabled: true
+displayName: Retail Example
+
+roles:
+  realm:
+    - name: CUSTOMER
+      description: Standard shop customer
+    - name: ADMIN
+      description: Shop administrator
+
+clients:
+  - clientId: shop-frontend
+    name: Shop Frontend
+    enabled: true
+    publicClient: true
+    standardFlowEnabled: true
+    directAccessGrantsEnabled: false
+    frontchannelLogout: true
+    redirectUris: $(KC_REDIRECT_URIS)
+    webOrigins: $(KC_WEB_ORIGINS)
+
+users:
+  - username: alice
+    enabled: true
+    email: alice@example.com
+    firstName: Alice
+    lastName: Example
+    realmRoles:
+      - CUSTOMER
+    credentials:
+      - type: password
+        value: "$(KC_TEST_USER_PASSWORD)"
+        temporary: false
+
+  - username: bob
+    enabled: true
+    email: bob@example.com
+    firstName: Bob
+    lastName: Example
+    realmRoles:
+      - CUSTOMER
+    credentials:
+      - type: password
+        value: "$(KC_TEST_USER_PASSWORD)"
+        temporary: false
+
+  - username: shopkeeper
+    enabled: true
+    email: shopkeeper@example.com
+    firstName: Shop
+    lastName: Keeper
+    realmRoles:
+      - CUSTOMER
+      - ADMIN
+    credentials:
+      - type: password
+        value: "$(KC_TEST_USER_PASSWORD)"
+        temporary: false

--- a/charts/infrastructure/keycloak/templates/_helpers.tpl
+++ b/charts/infrastructure/keycloak/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{/*
+Chart name.
+*/}}
+{{- define "keycloak.name" -}}
+{{- default "keycloak" .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified name. Defaults to "keycloak" so the in-cluster Service DNS name
+(used by the backend's jwk-set-uri) stays stable regardless of the release name.
+*/}}
+{{- define "keycloak.fullname" -}}
+{{- default "keycloak" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "keycloak.labels" -}}
+app.kubernetes.io/name: {{ include "keycloak.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}
+
+{{- define "keycloak.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keycloak.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/infrastructure/keycloak/templates/deployment.yaml
+++ b/charts/infrastructure/keycloak/templates/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "keycloak.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "keycloak.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: keycloak
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - start-dev
+          env:
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME
+              value: {{ .Values.admin.username | quote }}
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+              value: {{ .Values.admin.password | quote }}
+            - name: KC_HTTP_ENABLED
+              value: "true"
+            - name: KC_HTTP_RELATIVE_PATH
+              value: {{ .Values.http.relativePath | quote }}
+            - name: KC_HOSTNAME
+              value: {{ .Values.hostname | quote }}
+            - name: KC_PROXY_HEADERS
+              value: "xforwarded"
+            - name: KC_HOSTNAME_STRICT
+              value: "false"
+            - name: KC_HEALTH_ENABLED
+              value: "true"
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+            - name: management
+              containerPort: {{ .Values.service.managementPort }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.http.relativePath }}/health/ready
+              port: management
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.http.relativePath }}/health/live
+              port: management
+            initialDelaySeconds: 60
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 10
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/infrastructure/keycloak/templates/ingressroute.yaml
+++ b/charts/infrastructure/keycloak/templates/ingressroute.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.ingress.entryPoint }}
+  routes:
+    - kind: Rule
+      match: Host(`{{ .Values.ingress.host }}`) && PathPrefix(`{{ .Values.ingress.pathPrefix }}`)
+      services:
+        - name: {{ include "keycloak.fullname" . }}
+          port: {{ .Values.service.port }}
+{{- end }}

--- a/charts/infrastructure/keycloak/templates/realm-configmap.yaml
+++ b/charts/infrastructure/keycloak/templates/realm-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.realm.import.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "keycloak.fullname" . }}-realm
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+data:
+  retail-realm.yaml: |
+{{ .Files.Get "files/retail-realm.yaml" | indent 4 }}
+{{- end }}

--- a/charts/infrastructure/keycloak/templates/realm-import-job.yaml
+++ b/charts/infrastructure/keycloak/templates/realm-import-job.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.realm.import.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "keycloak.fullname" . }}-realm-import
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  backoffLimit: 5
+  template:
+    metadata:
+      labels:
+        {{- include "keycloak.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: keycloak-config-cli
+          image: "{{ .Values.realm.import.image.repository }}:{{ .Values.realm.import.image.tag }}"
+          env:
+            - name: KEYCLOAK_URL
+              value: "http://{{ include "keycloak.fullname" . }}:{{ .Values.service.port }}{{ .Values.http.relativePath }}"
+            - name: KEYCLOAK_USER
+              value: {{ .Values.admin.username | quote }}
+            - name: KEYCLOAK_PASSWORD
+              value: {{ .Values.admin.password | quote }}
+            - name: KEYCLOAK_AVAILABILITYCHECK_ENABLED
+              value: "true"
+            - name: KEYCLOAK_AVAILABILITYCHECK_TIMEOUT
+              value: "120s"
+            - name: IMPORT_FILES_LOCATION
+              value: "/config/"
+            - name: IMPORT_VARSUBSTITUTION_ENABLED
+              value: "true"
+            - name: KC_REDIRECT_URIS
+              value: {{ .Values.realm.import.redirectUris | quote }}
+            - name: KC_WEB_ORIGINS
+              value: {{ .Values.realm.import.webOrigins | quote }}
+            - name: KC_TEST_USER_PASSWORD
+              value: {{ .Values.realm.import.testUserPassword | quote }}
+          volumeMounts:
+            - name: realm-config
+              mountPath: /config
+              readOnly: true
+      volumes:
+        - name: realm-config
+          configMap:
+            name: {{ include "keycloak.fullname" . }}-realm
+{{- end }}

--- a/charts/infrastructure/keycloak/templates/service.yaml
+++ b/charts/infrastructure/keycloak/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "keycloak.fullname" . }}
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "keycloak.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/infrastructure/keycloak/values.yaml
+++ b/charts/infrastructure/keycloak/values.yaml
@@ -1,0 +1,44 @@
+replicaCount: 1
+
+image:
+  repository: quay.io/keycloak/keycloak
+  tag: "26.3"
+  pullPolicy: IfNotPresent
+
+# Bootstrap admin (Keycloak admin console). Demo credentials only.
+admin:
+  username: admin
+  password: admin
+
+http:
+  # Keycloak is served under this relative path (matches the docker-compose stack).
+  relativePath: /auth
+
+# Browser-facing base URL of Keycloak (through Traefik on :8080). This becomes the
+# token `iss` value, so the backend's issuer-uri must match it.
+hostname: "http://localhost:8080/auth"
+
+service:
+  port: 8080
+  managementPort: 9000
+
+# Traefik IngressRoute exposing Keycloak under {host}{pathPrefix}.
+ingress:
+  enabled: true
+  entryPoint: web
+  host: localhost
+  pathPrefix: /auth
+
+# Realm import via keycloak-config-cli (runs as a post-install/upgrade Helm hook).
+realm:
+  import:
+    enabled: true
+    image:
+      repository: adorsys/keycloak-config-cli
+      tag: "latest-26"
+    # Variable substitution values for files/retail-realm.yaml.
+    redirectUris: '["http://localhost:8080/*"]'
+    webOrigins: '["http://localhost:8080"]'
+    testUserPassword: test
+
+resources: {}

--- a/charts/shop-backend/templates/deployment.yaml
+++ b/charts/shop-backend/templates/deployment.yaml
@@ -45,3 +45,7 @@ spec:
               value: {{ index .Values.application "sample-data" "enabled" | quote }}
             - name: ISSUER_URI
               value: {{ index .Values.application.security "issuer-uri" | quote }}
+            {{- with (index .Values.application.security "jwk-set-uri") }}
+            - name: SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI
+              value: {{ . | quote }}
+            {{- end }}

--- a/charts/shop-backend/values.local.yaml
+++ b/charts/shop-backend/values.local.yaml
@@ -23,4 +23,9 @@ application:
   sample-data:
     enabled: true
   security:
-    issuer-uri: "https://retail-ddd-example.eu.auth0.com/"
+    # Keycloak realm issuer. Must match the `iss` claim in tokens (the browser-facing URL,
+    # served through Traefik on :8080).
+    issuer-uri: "http://localhost:8080/auth/realms/retail"
+    # JWKS is fetched from the in-cluster Keycloak Service, since the browser-facing
+    # issuer-uri above is not reachable from inside the cluster.
+    jwk-set-uri: "http://keycloak:8080/auth/realms/retail/protocol/openid-connect/certs"

--- a/charts/shop-backend/values.yaml
+++ b/charts/shop-backend/values.yaml
@@ -52,3 +52,7 @@ application:
     enabled: false
   security:
     issuer-uri: ""
+    # Optional: in-cluster JWKS endpoint. Set this when the browser-facing issuer-uri
+    # is not reachable from inside the cluster (e.g. Keycloak behind Traefik). The `iss`
+    # claim is still validated against issuer-uri; only key material is fetched from here.
+    jwk-set-uri: ""

--- a/charts/shop-frontend/templates/configmap.yaml
+++ b/charts/shop-frontend/templates/configmap.yaml
@@ -6,7 +6,6 @@ metadata:
     {{- include "shop-frontend.labels" . | nindent 4 }}
 data:
   app.env: |
-    SHOP_BACKEND_URL={{ required "shop-frontend: env.SHOP_BACKEND_URL is required" .Values.env.SHOP_BACKEND_URL }}
-    OAUTH_DOMAIN={{ required "shop-frontend: env.OAUTH_DOMAIN is required" .Values.env.OAUTH_DOMAIN }}
-    OAUTH_CLIENT_ID={{ required "shop-frontend: env.OAUTH_CLIENT_ID is required" .Values.env.OAUTH_CLIENT_ID }}
-    OAUTH_AUDIENCE={{ default "" .Values.env.OAUTH_AUDIENCE }}
+    KEYCLOAK_URL={{ required "shop-frontend: env.KEYCLOAK_URL is required" .Values.env.KEYCLOAK_URL }}
+    KEYCLOAK_REALM={{ required "shop-frontend: env.KEYCLOAK_REALM is required" .Values.env.KEYCLOAK_REALM }}
+    KEYCLOAK_CLIENT_ID={{ required "shop-frontend: env.KEYCLOAK_CLIENT_ID is required" .Values.env.KEYCLOAK_CLIENT_ID }}

--- a/charts/shop-frontend/values.local.yaml
+++ b/charts/shop-frontend/values.local.yaml
@@ -10,7 +10,6 @@ ingress:
           pathType: Prefix
 
 env:
-  SHOP_BACKEND_URL: "http://localhost:8080"
-  OAUTH_DOMAIN: "retail-ddd-example.eu.auth0.com"
-  OAUTH_CLIENT_ID: "22pHgiuTCCLFKHK7SMbWkCzohwar8knS"
-  OAUTH_AUDIENCE: ""
+  KEYCLOAK_URL: "http://localhost:8080/auth"
+  KEYCLOAK_REALM: "retail"
+  KEYCLOAK_CLIENT_ID: "shop-frontend"

--- a/charts/shop-frontend/values.yaml
+++ b/charts/shop-frontend/values.yaml
@@ -38,7 +38,7 @@ readinessProbe:
   failureThreshold: 3
 
 env:
-  SHOP_BACKEND_URL: ""
-  OAUTH_DOMAIN: ""
-  OAUTH_CLIENT_ID: ""
-  OAUTH_AUDIENCE: ""
+  # Browser-facing Keycloak settings, served at runtime via app.env.
+  KEYCLOAK_URL: ""
+  KEYCLOAK_REALM: ""
+  KEYCLOAK_CLIENT_ID: ""

--- a/services/shop/shop-backend/src/test/resources/application-test.yaml
+++ b/services/shop/shop-backend/src/test/resources/application-test.yaml
@@ -1,6 +1,6 @@
 SERVER_PORT: 0
 
-ISSUER_URI: https://retail-ddd-example.eu.auth0.com/
+ISSUER_URI: http://localhost:8080/auth/realms/retail
 
 DATABASE_URL: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
 DATABASE_USER: sa

--- a/services/shop/shop-e2e/README.md
+++ b/services/shop/shop-e2e/README.md
@@ -1,13 +1,18 @@
 # Shop E2E Tests
 
-End-to-end tests for the Shop service using Cypress with Auth0 authentication and Mochawesome reporting.
+End-to-end tests for the Shop service using Cypress with Keycloak authentication and Mochawesome reporting.
 
 ## Prerequisites
 
-- **Shop Frontend**: Running on `http://localhost:5173` (default)
-- **Shop Backend**: Running and accessible
+- **Running shop stack**: The simplest way is the bundled Docker Compose stack
+  (`cd stack && docker compose --profile with-shop up -d`), which serves the frontend, backend
+  and **Keycloak** behind a single nginx reverse proxy on `http://localhost:8080`.
 - **Node.js**: Version compatible with the project
 - **Environment Configuration**: `.env.local` file (see below)
+
+> **Why the reverse proxy matters:** the tests log in through the Keycloak login form. Because
+> Keycloak is served under the **same origin** as the app (`http://localhost:8080/auth`), no
+> Cypress `cy.origin()` boundary is needed. Point `CYPRESS_BASE_URL` at that single origin.
 
 ## Setup
 
@@ -22,14 +27,14 @@ npm install
 Create a `.env.local` file in the `services/shop/shop-e2e` directory with the following variables:
 
 ```env
-CYPRESS_BASE_URL=http://localhost:5173
-AUTH0_DOMAIN=your-auth0-domain.auth0.com
-AUTH0_USERNAME=test@example.com
-AUTH0_PASSWORD=your-password
-AUTH0_CLIENT_ID=your-client-id
+CYPRESS_BASE_URL=http://localhost:8080
+KEYCLOAK_USERNAME=alice
+KEYCLOAK_PASSWORD=test
 ```
 
-> **Note:** You can find the credentials in OnePassword under `Fullstack-Example-Configs`.
+> **Note:** `alice`, `bob` and `shopkeeper` (all password `test`) are the bundled test users from
+> the `retail` realm — see [stack/keycloak/retail-realm.yaml](../../../stack/keycloak/retail-realm.yaml).
+> No external accounts or secrets are required.
 
 ## Running Tests
 
@@ -93,7 +98,7 @@ const { ARTICLES } = PAGE;
 
 describe("Shop - Test Suite", function () {
     beforeEach(function () {
-        cy.login(); // Custom command for Auth0 login
+        cy.login(); // Custom command for Keycloak login
         cy.visit(ARTICLES);
         cy.get(`[data-testid^="${SHOP_ARTICLES.CARD}"]`)
           .should("have.length.greaterThan", 10);
@@ -113,18 +118,22 @@ describe("Shop - Test Suite", function () {
 
 **Login Command** (`cy.login()`)
 
-Handles Auth0 authentication flow and session management:
+Drives the Keycloak login form and manages the cached session:
 
 ```typescript
-cy.login(); // Uses default credentials from .env.local
-cy.login("user@example.com", "password"); // Custom credentials
+cy.login(); // Uses default credentials from .env.local (KEYCLOAK_USERNAME / KEYCLOAK_PASSWORD)
+cy.login("bob", "test"); // Custom realm credentials
 ```
+
+It visits the app (which redirects to Keycloak via `login-required`), submits the username and
+password, and waits for keycloak-js to persist the access token in `localStorage` under
+`dddToken`. The session is cached per user/spec with `cy.session()`.
 
 ### Test Data IDs
 
 All test selectors are centralized in `support/commands.ts` under the `DATA_TESTID` constant:
 
-- `DATA_TESTID.AUTH0.*` - Auth0 login selectors
+- `DATA_TESTID.KEYCLOAK.*` - Keycloak login selectors
 - `DATA_TESTID.SHOP_MENU.*` - Navigation menu elements
 - `DATA_TESTID.SHOP_ARTICLES.*` - Article list and cards
 - `DATA_TESTID.SHOP_CART.*` - Shopping cart elements
@@ -156,7 +165,7 @@ Page paths are defined in `support/commands.ts` under the `PAGE` constant:
 
 Each test typically follows this pattern:
 
-1. **Login**: Authenticate via Auth0
+1. **Login**: Authenticate via Keycloak
 2. **Navigate**: Visit the target page
 3. **Interact**: Perform actions (click, type, select)
 4. **Assert**: Verify expected outcomes
@@ -171,7 +180,7 @@ Detailed test specifications are documented per suite in `Testspecifications/`.
 
 ### Coverage Summary
 
-- Authentication (Auth0 login/logout)
+- Authentication (Keycloak login/logout)
 - Navigation menu interactions
 - Shopping cart CRUD operations
 - Order creation and confirmation
@@ -199,11 +208,11 @@ When adding a new suite:
 
 Ensure you're running tests in headless mode using `npm run cy:all` or `npm run cy:spec`. Interactive mode (`npm run cy`) does not generate Mochawesome reports.
 
-### Auth0 authentication failures
+### Keycloak authentication failures
 
-- Verify credentials in `.env.local`
-- Check that `AUTH0_DOMAIN` matches your Auth0 tenant
-- Ensure the Auth0 application is properly configured
+- Verify `KEYCLOAK_USERNAME` / `KEYCLOAK_PASSWORD` in `.env.local` match a realm user (default: `alice` / `test`)
+- Make sure Keycloak is up and the `retail` realm was imported (`http://localhost:8080/auth/admin`, `admin` / `admin`)
+- Ensure `CYPRESS_BASE_URL` points at the reverse proxy origin that also serves Keycloak (`http://localhost:8080`), so the login form stays same-origin
 
 ### Frontend not accessible
 

--- a/services/shop/shop-e2e/Testspecifications/basic.md
+++ b/services/shop/shop-e2e/Testspecifications/basic.md
@@ -7,7 +7,7 @@
 ## Setup
 
 ### Before Each Test
-1. Authenticate user via Auth0 (`cy.login()`)
+1. Authenticate user via Keycloak (`cy.login()`)
 2. Navigate to articles page (`/articles`)
 3. Verify at least 10 article cards are visible
 
@@ -17,10 +17,10 @@
 **Action:** User logs out of the application
 **Steps:**
 1. Click logout button in menu
-2. User is redirected to Auth0 login page
+2. User is redirected to the Keycloak login page
 
 **Verification:**
-- Auth0 username input field is visible
+- Keycloak username input field is visible
 
 **Test Data:** None required
 
@@ -109,7 +109,7 @@
 All tests depend on:
 - Shop backend running and accessible
 - Shop frontend running on configured `CYPRESS_BASE_URL`
-- Auth0 authentication service available
+- Keycloak authentication service available (realm `retail`)
 - Test user credentials configured in `.env.local`
 - Article catalog containing at least the following items:
   - Samsung 980 PRO 1TB SSD

--- a/services/shop/shop-e2e/cypress.config.ts
+++ b/services/shop/shop-e2e/cypress.config.ts
@@ -3,8 +3,7 @@ import PluginEvents = Cypress.PluginEvents;
 import PluginConfigOptions = Cypress.PluginConfigOptions;
 
 console.info('CYPRESS_BASE_URL:', process.env.CYPRESS_BASE_URL);
-console.info('AUTH0_DOMAIN:', process.env.AUTH0_DOMAIN);
-console.info('AUTH0_USERNAME:', process.env.AUTH0_USERNAME);
+console.info('KEYCLOAK_USERNAME:', process.env.KEYCLOAK_USERNAME);
 
 export default defineConfig({
     port: 8101,
@@ -51,13 +50,8 @@ export default defineConfig({
             runMode: 1,
         },
         env: {
-            auth0Username: process.env.AUTH0_USERNAME,
-            auth0Password: process.env.AUTH0_PASSWORD,
-            auth0ClientId: process.env.AUTH0_CLIENT_ID
-        },
-        expose: {
-            auth0Domain: process.env.AUTH0_DOMAIN,
-            baseUrl: process.env.CYPRESS_BASE_URL
+            keycloakUsername: process.env.KEYCLOAK_USERNAME,
+            keycloakPassword: process.env.KEYCLOAK_PASSWORD
         },
         //
         setupNodeEvents: (on: PluginEvents, config: PluginConfigOptions) => {

--- a/services/shop/shop-e2e/e2e/basic.spec.ts
+++ b/services/shop/shop-e2e/e2e/basic.spec.ts
@@ -2,7 +2,7 @@ import {DATA_TESTID} from "../support/commands";
 import {PAGE} from "../support/commands";
 
 const {
-    AUTH0,
+    KEYCLOAK,
     SHOP_ARTICLES,
     SHOP_CART,
     SHOP_MENU,
@@ -24,7 +24,7 @@ describe("Shop - Menubar Testsuite", function (): void {
 
     it("Logout (#prb)", function () {
         cy.get(SHOP_MENU.LOGOUT).click();
-        cy.get(AUTH0.USERNAME).should("be.visible");
+        cy.get(KEYCLOAK.USERNAME).should("be.visible");
     });
     it("Add article to cart (#unn)", function () {
         cy.get(`[data-testid="${SHOP_ARTICLES.ADD_TO_CART(SHOP_ARTICLES.ITEMS.SAMSUNG.ID)}"]`).click();

--- a/services/shop/shop-e2e/support/commands.ts
+++ b/services/shop/shop-e2e/support/commands.ts
@@ -8,10 +8,10 @@ declare global {
 }
 
 export const DATA_TESTID = {
-    AUTH0: {
+    KEYCLOAK: {
         USERNAME: "input#username",
         PASSWORD: "input#password",
-        SUBMIT: "button[data-action-button-primary=true]:contains(Continue)"
+        SUBMIT: "#kc-login"
     },
     // Cart-IconButton-f2b5c8a0-1d3e-4c5b-9f3e-7d6f8a2b1c3d
     SHOP_MENU: {
@@ -81,73 +81,51 @@ export const PAGE = {
     CART: "/cart"
 } as const;
 
-const TOKEN = `https://${Cypress.expose("auth0Domain")}/oauth/token`;
+// keycloak-js stores the access token here once the OIDC login flow completes.
+const TOKEN_STORAGE_KEY = "dddToken";
+
+// Retries until keycloak-js has persisted the access token in localStorage.
+const expectAuthenticated = (): void => {
+    cy.window({timeout: 30000}).should(win => {
+        expect(win.localStorage.getItem(TOKEN_STORAGE_KEY)).to.be.a("string");
+    });
+};
 
 Cypress.Commands.add("login", function (username, password) {
     Cypress.log({
-        displayName: "AUTH0 LOGIN",
+        displayName: "KEYCLOAK LOGIN",
         message: [`🔐 Session | ${Cypress.spec.name}`]
     });
-    // NOTE: the session ID has to be unique for each user login to avoid conflicts
-    cy.env(["auth0Username", "auth0Password", "auth0ClientId"]).then(credentials => {
-        const {auth0Username, auth0Password, auth0ClientId} = credentials;
-        if (username === undefined || password === undefined) {
-            username = auth0Username;
-            password = auth0Password;
-        }
+    // `env` values are read via cy.env() (project runs with allowCypressEnv: false).
+    cy.env(["keycloakUsername", "keycloakPassword"]).then(credentials => {
+        const {keycloakUsername, keycloakPassword} = credentials;
+        const user = username ?? keycloakUsername;
+        const pass = password ?? keycloakPassword;
+        // NOTE: the session ID is unique per test. Sharing a session across the spec
+        // breaks once a test logs out (it invalidates the Keycloak server session),
+        // so each test gets its own clean login.
         cy.session(
-            `${username}-${Cypress.spec.name}`,
+            `${user}-${Cypress.spec.name}-${Cypress.currentTest.title}`,
             () => {
-                const {AUTH0} = DATA_TESTID;
-                cy.intercept("POST", TOKEN).as("token");
+                const {KEYCLOAK} = DATA_TESTID;
                 cy.clearAllSessionStorage();
                 cy.clearAllCookies();
                 cy.clearAllLocalStorage();
-                // App landing page redirects to Auth0.
-                cy.visit("/")
-                cy.get(AUTH0.USERNAME).should("be.visible");
-                // Login to Auth0 and receive the token.
-                cy.origin(
-                    Cypress.expose("auth0Domain"),
-                    {args: {username, password, AUTH0}},
-                    ({username, password, AUTH0}) => {
-                        cy.get(AUTH0.SUBMIT).as("submit");
-                        cy.get("@submit").should("be.visible");
-                        cy.get(AUTH0.USERNAME).as("un");
-                        cy.get("@un").clear();
-                        cy.get("@un")
-                            .should("have.value", "");
-                        cy.get("@un")
-                            .type(username, {delay: 50});
-                        cy.get("@un")
-                            .should("have.value", username);
-                        cy.get(AUTH0.PASSWORD).as("pw");
-                        cy.get("@pw").clear();
-                        cy.get("@pw")
-                            .should("have.value", "");
-                        cy.get("@pw")
-                            .type(password, {delay: 50, log: false});
-                        cy.get("@pw")
-                            .should("have.value", password);
-                        cy.get("@submit").click();
-                        // wait for the token, then get redirected
-                        cy.wait("@token");
-                    }
-                );
-            }, // session created
+                // The app boots with keycloak-js `login-required`, so visiting it
+                // immediately redirects to the Keycloak login form. Keycloak is served
+                // under the same origin (behind the nginx/Traefik reverse proxy on :8080),
+                // so no cy.origin() boundary is required.
+                cy.visit("/");
+                cy.get(KEYCLOAK.USERNAME).should("be.visible").clear().type(user);
+                cy.get(KEYCLOAK.PASSWORD).clear().type(pass, {log: false});
+                cy.get(KEYCLOAK.SUBMIT).click();
+                // After a successful login Keycloak redirects back and keycloak-js
+                // persists the access token.
+                expectAuthenticated();
+            },
             {
-                validate: () => {
-                    cy.getCookie(`auth0.${auth0ClientId}.is.authenticated`)
-                        .then($cookie => {
-                            expect($cookie.value).eq("true");
-                        });
-                    cy.getCookie(`_legacy_auth0.${auth0ClientId}.is.authenticated`)
-                        .then($cookie => {
-                            expect($cookie.value).eq("true");
-                        });
-                },
+                validate: expectAuthenticated,
                 cacheAcrossSpecs: false
             });
-    });// blank page
-    // cy.get("[data-cy='cypress-logo']").should("be.visible"); // wait for the blank page
+    });
 });


### PR DESCRIPTION
## Summary

Completes the migration from Auth0 to **self-hosted Keycloak** that was started in the keycloak spike (#61). The frontend/backend source already used keycloak-js / a realm issuer; this PR finishes the remaining surfaces — Helm charts, the Cypress e2e suite, and all docs — so there are no Auth0 references left anywhere.

## Changes

### In-cluster Keycloak Helm chart (new)
- `charts/infrastructure/keycloak/` — Deployment (`keycloak:26.3`, `start-dev`, `/auth` relative path), Service (`keycloak:8080`), Traefik `IngressRoute` at `/auth`, realm `ConfigMap`, and a realm-import `Job` (`keycloak-config-cli`, Helm post-install hook). Imports the `retail` realm with test users `alice`/`bob`/`shopkeeper`.

### Charts wired to Keycloak
- **shop-frontend**: configmap/values emit `KEYCLOAK_URL`/`KEYCLOAK_REALM`/`KEYCLOAK_CLIENT_ID` (the runtime contract the app reads); removed `OAUTH_*` and the unused `SHOP_BACKEND_URL`.
- **shop-backend**: `issuer-uri` → realm; added `jwk-set-uri` (mapped to `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI`) so the pod fetches JWKS from the in-cluster service while still validating the browser-facing `iss` — no backend code change required.

### E2E (Cypress) → Keycloak
- Login command drives the Keycloak login form (same-origin behind the reverse proxy, no `cy.origin()`), reads creds via `cy.env()`, validates via the `dddToken` in `localStorage`, and uses a per-test `cy.session` (a shared session broke once the logout test invalidated the Keycloak server session).
- `.env.local` now needs only `CYPRESS_BASE_URL` + `KEYCLOAK_USERNAME`/`KEYCLOAK_PASSWORD`.

### Docs / misc
- `README.md`, `CLAUDE.md`, `charts/README.md` updated for the Keycloak setup; backend test `ISSUER_URI` → realm.

## Test plan
- ✅ `helm lint` + render of the keycloak chart (5 valid docs; embedded realm parses: `retail` / `shop-frontend` / `alice,bob,shopkeeper`). shop-frontend & shop-backend charts render with the new wiring.
- ✅ **E2E: `npm run cy:all` → 5/5 passing** against the live docker-compose stack (Keycloak + frontend + backend), Chrome headless.
- ✅ `./gradlew :services:shop:shop-backend:test` passes.

## Note (out of scope)
`stack/nginx/nginx.conf` routes `/` and `/api` via `resolver 127.0.0.11` (Docker's embedded DNS), which 502s under podman. Not touched here since it looks intentional for the Docker host-dev workflow — can be addressed separately.