### PR TITLE
chore: add issue templates and group dependabot github-actions updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug Report
+description: Report a bug or unexpected behaviour in the Miravelo shop example
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill in the details below to help us reproduce and fix the issue.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected Component
+      description: Which part of the project is affected?
+      options:
+        - shop-backend
+        - delivery-backend
+        - warehouse-backend
+        - shop-mcp-client
+        - shop-frontend
+        - infra / stack (Docker, Keycloak, Helm)
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Step-by-step instructions to reproduce the behaviour.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behaviour
+      description: What actually happened? Include logs, stack traces, or screenshots if relevant.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,66 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for the Miravelo shop example
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature! Please describe what you'd like to see and why it would be useful.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected Component
+      description: Which part of the project would this feature touch?
+      options:
+        - shop-backend
+        - delivery-backend
+        - warehouse-backend
+        - shop-mcp-client
+        - shop-frontend
+        - infra / stack (Docker, Keycloak, Helm)
+        - Other / not sure
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear and concise description of the feature you are requesting.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this feature needed? What problem does it solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How should the feature work? Include any relevant details.
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: What conditions must be met for this feature to be considered complete?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or approaches you've considered?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/refactoring.yml
+++ b/.github/ISSUE_TEMPLATE/refactoring.yml
@@ -1,0 +1,66 @@
+name: Refactor
+description: Propose a code refactoring or structural improvement
+title: "[Refactor]: "
+labels:
+  - "Technical Debt"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for proposing a refactoring! Please describe the current state, the target state, and the motivation.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Affected Component
+      description: Which part of the project does this refactoring concern?
+      options:
+        - shop-backend
+        - delivery-backend
+        - warehouse-backend
+        - shop-mcp-client
+        - shop-frontend
+        - infra / stack (Docker, Keycloak, Helm)
+        - Cross-cutting / multiple
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What will be refactored and why?
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-state
+    attributes:
+      label: Current State
+      description: Describe the current implementation and its shortcomings.
+    validations:
+      required: true
+
+  - type: textarea
+    id: target-state
+    attributes:
+      label: Target State
+      description: Describe what the code should look like after the refactoring.
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of Scope
+      description: What will NOT be changed by this refactor?
+    validations:
+      required: false
+
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / Considerations
+      description: Any breaking changes, migration steps, or risks to be aware of?
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,14 @@ updates:
       - "Technical Debt"
     assignees:
       - "emaarco"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+          - "minor"
+          - "major"
 
   # Config for all gradle dependencies
   - package-ecosystem: "gradle"


### PR DESCRIPTION
Closes #55

## Summary

Three GitHub/DX configuration improvements.

### 1. Issue templates (`.github/ISSUE_TEMPLATE/`)
- `bug_report.yml` — bug form with a component dropdown (shop/delivery/warehouse/mcp/frontend/infra), label `bug`
- `feature_request.yml` — feature form with component dropdown, label `enhancement`
- `refactoring.yml` — refactor form with component dropdown, label `Technical Debt`
- `config.yml` — `blank_issues_enabled: true`

### 2. Group Dependabot GitHub Actions updates
Added a `groups` block to the `github-actions` ecosystem in `.github/dependabot.yml` so action bumps combine into a single PR. Gradle and npm grouping unchanged.

## Notes
- The reference templates linked in the issue (`emaarco/bpmn-to-code`) have moved and now 404. The identical set (same filenames) from `emaarco/engine-safari` was used as the basis and adapted to the Miravelo shop example.
- Used the existing `Technical Debt` label for the refactor template (no `refactor` label exists in this repo).
- `config.yml` omits `contact_links` because Discussions are disabled on this repo.

## Verification
- All five YAML files parse cleanly (validated with `yq`).
- Referenced labels (`bug`, `enhancement`, `Technical Debt`) all exist in the repo.