### PR TITLE
docs: migrate portless parallel-dev guide to docs/how-to

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,34 +138,23 @@ Each service implements its own article repository following the same domain mod
 
 ## Local Development Setup
 
-### Parallel-Dev (mehrere Checkouts, portless)
+Two ways to run the stack locally:
 
-Einmalig pro Checkout: `npm --prefix scripts install` (installiert portless lokal).
+- **Parallel-Dev (portless):** one isolated stack per branch/worktree, branch-unique
+  URLs, no port collisions. `npm --prefix scripts run dev` (after a one-time
+  `npm --prefix scripts install`). Full guide:
+  `docs/how-to/portless-parallel-development.md`.
+- **Single-origin (nginx):** single checkout via one nginx entry point on `:8080`.
 
-```bash
-npm --prefix scripts run dev        # Compose-Stack + alle Backends/Vite via portless
-npm --prefix scripts run dev:down   # Stack stoppen
-```
+  ```bash
+  cd stack && docker compose --profile solo up -d   # Postgres + Keycloak + nginx (:8080)
+  SPRING_PROFILES_ACTIVE=dev ./gradlew :services:shop:shop-backend:bootRun
+  npm --prefix services/shop/shop-frontend run dev  # Vite :5173
+  # App: http://localhost:8080  (Login alice/test)
+  ```
 
-Pro Branch-Checkout entstehen branch-spezifische URLs (`http://app.<slug>.localhost:1355`,
-`http://shop.<slug>.localhost:1355`, ...) und ein eigener Compose-Stack (Postgres +
-Keycloak) auf hash-derivierten Ports. Zwei Worktrees auf unterschiedlichen
-Branches laufen so kollisionsfrei parallel. Details: `stack/README.md`.
-
-### Lokal single-origin (single-clone, ohne portless)
-
-```bash
-cd stack && docker compose --profile solo up -d   # Postgres + Keycloak + nginx (:8080)
-SPRING_PROFILES_ACTIVE=dev ./gradlew :services:shop:shop-backend:bootRun
-npm --prefix services/shop/shop-frontend run dev  # Vite :5173
-# App: http://localhost:8080  (Login alice/test)
-```
-
-nginx auf `:8080` ist der einzige Entry-Point: `/` → Vite, `/api` → Backend
-(festen dev-Ports 8081/8082/8083/8085), `/auth` → Keycloak. Keycloak-Admin direkt
-unter `:8088/auth`. Das `--profile solo` ist nötig (sonst startet nginx nicht);
-`dev.sh` lässt es weg, damit nginx im portless-Modus aus bleibt. Details und
-Helm/Minikube-Alternative: `stack/README.md` bzw. `charts/README.md`.
+Details for both modes (and the Helm/Minikube alternative): `stack/README.md` and
+`charts/README.md`.
 
 ## Testing Strategy
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 🚲 Miravelo — DDD Bike Shop Example
+# 🚲 Miravelo — Bike Shop Example
 
-> *A showcase of how multiple teams can collaborate in a monorepo using Domain-Driven Design*
+> *A showcase of how multiple teams can collaborate in a monorepo*
 
 **Miravelo** is our standard scenario for trainings, workshops and demos — a (fictional) lifestyle
 bike shop selling gravel bikes for weekends in the woods, road bikes for after-work loops, and
@@ -8,30 +8,29 @@ accessories nobody strictly needs but everybody *feels*. It gives every example 
 narrative ("we're building features for a shop") that anyone understands instantly — so the focus
 stays on the architecture, not the domain.
 
-Welcome to our **Domain-Driven Design** showcase!
-This isn't just another "Hello World" - it's a **multi-team monorepo** demonstrating how different bounded contexts can
-coexist, evolve independently, and work together in harmony.
-We've got hexagons, bounded contexts, and more patterns than a textile factory.
+Welcome to the showcase!
+This isn't just another "Hello World" - it's a **multi-team monorepo** demonstrating how independent
+**bounded contexts** can coexist, evolve independently, and work together in harmony.
 
 ## 🎯 What's This All About?
 
-This project demonstrates how **multiple development teams** can work effectively in a **single repository** using **DDD
-principles**, **bounded contexts**, and **Hexagonal Architecture**.
+This project demonstrates how **multiple development teams** can work effectively in a **single repository** with
+clear service boundaries and a shared toolchain.
 
 **Key Concepts Demonstrated:**
 
 - 🏢 **Multi-team ownership** - Each service represents a different team's domain
-- 🔒 **Bounded contexts** - Clear domain boundaries with explicit interfaces
+- 🔒 **Clear service boundaries** - Explicit interfaces between independent services
 - 📦 **Monorepo benefits** - Shared tooling, unified CI/CD, cross-cutting concerns
 - 🏗️ **Independent deployability** - Teams can deploy their services autonomously
 - 📋 **Documentation-driven development** - ADRs, architectural guidelines, and decision tracking
 
-Think of it as a **digital shopping mall** where each team owns their "store" (bounded context) but shares the
+Think of it as a **digital shopping mall** where each team owns their "store" but shares the
 infrastructure, while maintaining clear ownership and autonomy.
 
 ## 🏬 The Domain: The Miravelo bike shop
 
-The domain is **Miravelo**, a bike e-commerce platform with multiple bounded contexts,
+The domain is **Miravelo**, a bike e-commerce platform with multiple services,
 each representing a different aspect of the business:
 
 - **🛒 Shop Service**: The main attraction - handles articles (bikes & gear), orders, and all that e-commerce jazz
@@ -112,6 +111,11 @@ You can also run the backends/frontend directly while keeping the infrastructure
    - **Frontend**: `cd services/shop/shop-frontend && yarn dev`.
      Local Keycloak settings live in
      [services/shop/shop-frontend/public/app.env](services/shop/shop-frontend/public/app.env).
+
+> Working on several branches at once? The **portless parallel-dev** setup gives each
+> worktree its own isolated stack and branch-unique URLs, so you can run multiple
+> variants side by side without port conflicts. See
+> [docs/how-to/portless-parallel-development.md](docs/how-to/portless-parallel-development.md).
 
 ### Running on Minikube (alternative)
 

--- a/docs/how-to/portless-parallel-development.md
+++ b/docs/how-to/portless-parallel-development.md
@@ -1,0 +1,167 @@
+# 🛣️ Portless Parallel-Dev: running multiple branches at once
+
+AI is shifting the bottleneck of software development. Code now appears faster than
+ever — several features in parallel, each in its own worktree. What slows things down
+afterwards is no longer the writing, but **review and testing**: before a branch gets
+merged, you want to *see it running*.
+
+This is exactly where a technical obstacle used to sit: **port conflicts.** Two
+checkouts of the same project both want Postgres on `5432`, Keycloak on `8080`, the
+backend on `8081`, and Vite on `5173`. The moment you tried to start two variants at
+once — one to test, one to keep building — everything collided.
+
+**Portless solves this testing bottleneck.** Every worktree gets its own, fully
+isolated stack and unique URLs. You can run as many variants of the project in
+parallel as you like — one per branch — and try them out side by side without
+anything getting in each other's way.
+
+> This document covers the **portless mode** (parallel dev). If you only work on a
+> *single* branch, the simpler single-origin mode (nginx on `:8080`) is the better
+> fit — see [`stack/README.md`](../../stack/README.md).
+
+## 🚀 Quick start
+
+```bash
+npm --prefix scripts install        # once per checkout: installs portless
+npm --prefix scripts run dev        # bring up the stack + all backends/frontend via portless
+npm --prefix scripts run dev:down   # stop Compose (portless processes via Ctrl-C in dev)
+```
+
+`dev:down` stops the current branch's stack and additionally cleans up orphaned
+`miravelo-*` stacks whose Compose file no longer exists (e.g. deleted worktrees).
+Stacks of live worktrees (Compose file still present) keep running — that is exactly
+what makes parallel dev possible.
+
+## 🌐 Entry points
+
+Each branch gets its own URLs. `$BRANCH_SLUG` is derived from
+`git rev-parse --abbrev-ref HEAD` (lowercased, `/` and `_` replaced with `-` —
+e.g. `spike-keycloak-portless`).
+
+| URL                                              | Target                       |
+|--------------------------------------------------|------------------------------|
+| `http://app.${BRANCH_SLUG}.localhost:1355`       | Frontend (Vite)              |
+| `http://shop.${BRANCH_SLUG}.localhost:1355`      | shop-backend                 |
+| `http://delivery.${BRANCH_SLUG}.localhost:1355`  | delivery-backend             |
+| `http://warehouse.${BRANCH_SLUG}.localhost:1355` | warehouse-backend            |
+| `http://auth.${BRANCH_SLUG}.localhost:1355`      | Keycloak                     |
+| `http://auth.${BRANCH_SLUG}.localhost/admin`     | Keycloak Admin (admin/admin) |
+
+Postgres is not reachable through portless (no HTTP) — connect directly on
+`localhost:${POSTGRES_PORT}` (see the `dev-env.sh` output on startup).
+
+### Test users (realm: miravelo)
+
+| User       | Password | Roles           |
+|------------|----------|-----------------|
+| alice      | test     | CUSTOMER        |
+| bob        | test     | CUSTOMER        |
+| shopkeeper | test     | CUSTOMER, ADMIN |
+
+## ⚙️ How portless works
+
+[portless](https://github.com/vercel-labs/portless) is a local reverse proxy that
+occupies **one** port (`1355`) and routes to local processes based on the host name.
+`*.localhost` resolves automatically to `127.0.0.1` on macOS/Linux — no editing of
+`/etc/hosts`, no TLS, no sudo (unprivileged port). That way the entire branch only
+needs this single port facing outward; all service ports underneath are ephemeral.
+
+`dev.sh` uses portless in two ways:
+
+1. **Alias to a fixed port** — Keycloak runs in the Compose container on the
+   hash-derived host port `${KEYCLOAK_PORT}`. `portless alias auth.<slug>
+   <KEYCLOAK_PORT>` maps the branch host name onto this existing port. The port must
+   be known up front (portless only aliases to an *already* bound port) and be
+   deterministic from the slug, so parallel worktrees don't collide. The same applies
+   to Postgres, which doesn't run through portless at all (raw TCP) but is addressed
+   directly via `localhost:${POSTGRES_PORT}` in `DATABASE_URL`.
+2. **Process with an ephemeral port** — `portless <hostname> <command>` starts a
+   process, injects a free `PORT` env var, reads the actual port, and routes the host
+   name there. The Spring backends bind via `server.port: ${PORT:8080}` (see
+   `application.yml`), and Vite respects `PORT` too. That's why `dev-env.sh` does
+   `unset SPRING_PROFILES_ACTIVE`: the `dev` profile would otherwise override the
+   portless assignment with its fixed port.
+
+## 🧬 Branch isolation
+
+Two worktrees running side by side without collisions comes from two mechanisms
+working together:
+
+- **`dev-env.sh`** derives deterministic host ports (Postgres/Keycloak) and the
+  `COMPOSE_PROJECT_NAME` from the branch slug via `cksum` → two branches collide
+  neither on container ports nor on Compose projects.
+- **portless host names** carry the slug (`app.<slug>.localhost`, …) → the
+  browser/backend URLs are unique per branch, including `ISSUER_URI`,
+  `CORS_ALLOWED_ORIGINS`, and Keycloak `redirect_uris` (set per slug by
+  `keycloak-config-cli`).
+
+The result: a complete stack per branch — its own Postgres, its own Keycloak, its own
+backends, its own frontend — all reachable simultaneously under branch-unique URLs.
+Exactly what you need to test one variant while you keep working on the next.
+
+## ⚖️ Approach comparison
+
+When you want to run several variants of the project in parallel, there is more than
+one way to go about it — and the choice has real consequences for production parity,
+isolation, and resource usage. Three approaches are worth comparing:
+
+| Criterion         | **A: Per-branch stack** | **B: Stackless** (H2 + no-secure) | **C: Shared stack** (infra on main, branch only FE/BE) |
+|-------------------|-------------------------|-----------------------------------|--------------------------------------------------------|
+| Prod parity DB    | ✅ real Postgres         | ❌ H2 ≠ Postgres                   | ✅ real Postgres                                        |
+| Prod parity auth  | ✅ real Keycloak/OIDC    | ❌ security disabled               | ✅ real Keycloak/OIDC                                   |
+| Branch isolation  | ✅ complete              | ✅ (nothing shared)                | ❌ shared DB & realm state                              |
+| Resources         | ❌ 2 containers + JVMs per branch | ✅ minimal               | 🟡 1× infra total + JVMs per branch                    |
+| Startup/branch    | ❌ Keycloak health ~60 s | ✅ seconds                         | ✅ only FE/BE to start                                  |
+| Maintenance       | 🟡 more moving parts    | ❌ separate no-secure profile      | 🟡 wildcard realm + migration discipline               |
+
+**A: Per-branch stack — a dedicated stack (Postgres + Keycloak) *and* all services per
+branch.** Full production parity and full isolation; the price is resources (two
+containers plus JVMs per branch) and a ~60 s Keycloak health wait on startup.
+
+**B: Stackless (H2 + no-secure profile) — no parity.**
+Fastest start, no Docker. But the project stands and falls with exactly the parts
+that B abstracts away:
+
+- The schema is created via **Flyway**, and Hibernate runs with `ddl-auto: validate`
+  against Postgres-written DDL (`UUID`, `DOUBLE PRECISION`, `TIMESTAMP`). Under H2 you
+  would either have to maintain H2-compatible migrations or give up `validate` — both
+  undermine the point of the migration tests.
+- There is **no** no-secure profile; `application.yml` requires a real `ISSUER_URI`.
+  You would have to build such a profile and maintain it in parallel with the real
+  `SecurityConfig` (roles `CUSTOMER`/`ADMIN`, JWT, CORS) — it is guaranteed to drift,
+  and that's exactly where the interesting bugs live.
+
+Bottom line: B is fine for pure domain/unit work (there are already tests for that),
+but not for locally verifying auth and persistence behavior. Since this repo hosts a
+Keycloak spike among other things, missing parity would be especially harmful here.
+
+**C: Shared stack (infra once, branch only starts FE/BE).**
+Keeps A's parity and saves the most resources (one Postgres, one Keycloak instead of
+n×2 containers; branches start without the Keycloak wait). The price is the loss of
+isolation — and isolation is the actual purpose of the parallel-dev setup:
+
+- **Shared DB:** branches overwrite each other's data. Worse: Flyway migrations
+  diverge per branch. If a branch adds `V2`, it migrates the shared DB and breaks
+  `validate` on main/other branches.
+- **Shared realm:** `keycloak-config-cli` sets `redirect_uris`/`web-origins` per slug
+  today. With a shared Keycloak you'd need wildcard origins for all branch host
+  names, and one branch's realm changes immediately hit everyone.
+
+C is a sensible **opt-in optimization** when resource pressure is high *and* branches
+rarely touch the schema or realm. As the default, you'd lose exactly the
+collision-freedom that A guarantees.
+
+**We chose A.** It is the right default as long as only a few worktrees run at once and
+correctness around auth + DB migrations matters (both core topics of this repo). The
+resource downside could later be softened by an optional C-mode flag, without giving
+up A as the safe default.
+
+## 📂 Related files
+
+- [`scripts/dev.sh`](../../scripts/dev.sh) — starts the stack + portless processes
+- [`scripts/dev-env.sh`](../../scripts/dev-env.sh) — derives the slug, ports, and
+  `COMPOSE_PROJECT_NAME` from the branch
+- [`scripts/dev-down.sh`](../../scripts/dev-down.sh) — stops and cleans up
+- [`stack/README.md`](../../stack/README.md) — stack overview + single-origin mode
+- [`stack/docker-compose.yml`](../../stack/docker-compose.yml) — both setups from one
+  file

--- a/stack/README.md
+++ b/stack/README.md
@@ -4,10 +4,11 @@ Dev-Infrastruktur (Postgres + Keycloak) für zwei Setups aus **einer**
 `docker-compose.yml`:
 
 - **Portless (parallel):** pro Checkout ein eigener Stack, Routing zu lokalen
-  Backend-/Frontend-Prozessen via [portless](http://github.com/vercel-labs/portless).
+  Backend-/Frontend-Prozessen via [portless](https://github.com/vercel-labs/portless).
   Mehrere Branches laufen kollisionsfrei parallel.
+  → Vollständige Anleitung: [docs/how-to/portless-parallel-development.md](../docs/how-to/portless-parallel-development.md).
 - **Lokal (single-origin):** ein nginx auf `:8080` als einziger Entry-Point, der
-  Frontend, `/api` und Keycloak (`/auth`) unter einer Herkunft bündelt.
+  Frontend, `/api` und Keycloak (`/auth`) unter einer Herkunft bündelt (siehe unten).
 
 ## Start — Portless (parallel)
 
@@ -17,75 +18,10 @@ npm --prefix scripts run dev        # Stack hoch + alle Backends/Frontend via po
 npm --prefix scripts run dev:down   # Compose stoppen (portless-Prozesse via Ctrl-C in dev)
 ```
 
-`dev:down` stoppt den Stack des aktuellen Branches und räumt zusätzlich
-verwaiste `miravelo-*`-Stacks auf, deren Compose-Datei nicht mehr existiert (z.B.
-gelöschte Worktrees). Stacks lebender Worktrees (Compose-Datei noch vorhanden)
-bleiben laufen, damit Parallel-Dev funktioniert.
-
-`scripts/dev-env.sh` leitet aus dem aktuellen Git-Branch einen Slug ab und
-berechnet daraus deterministische Host-Ports für Postgres und Keycloak.
-Zwei Checkouts auf verschiedenen Branches laufen so kollisionsfrei parallel.
-
-## Einstiegspunkte
-
-`$BRANCH_SLUG` ergibt sich aus `git rev-parse --abbrev-ref HEAD` (Kleinbuchstaben,
-`/` und `_` durch `-` ersetzt — z.B. `spike-keycloak-portless`).
-
-| URL                                              | Ziel                         |
-|--------------------------------------------------|------------------------------|
-| `http://app.${BRANCH_SLUG}.localhost:1355`       | Frontend (Vite)              |
-| `http://shop.${BRANCH_SLUG}.localhost:1355`      | shop-backend                 |
-| `http://delivery.${BRANCH_SLUG}.localhost:1355`  | delivery-backend             |
-| `http://warehouse.${BRANCH_SLUG}.localhost:1355` | warehouse-backend            |
-| `http://auth.${BRANCH_SLUG}.localhost:1355`      | Keycloak                     |
-| `http://auth.${BRANCH_SLUG}.localhost/admin`     | Keycloak Admin (admin/admin) |
-
-Postgres ist nicht über portless erreichbar (kein HTTP) — Verbindung direkt
-auf `localhost:${POSTGRES_PORT}` (siehe `dev-env.sh`-Ausgabe beim Start).
-
-## Wie portless funktioniert
-
-[portless](https://github.com/vercel-labs/portless) ist ein lokaler
-Reverse-Proxy, der **einen** Port (`1355`) belegt und anhand des Host-Namens auf
-lokale Prozesse routet. `*.localhost` löst auf macOS/Linux automatisch auf
-`127.0.0.1` auf — kein `/etc/hosts`-Editieren, kein TLS, kein sudo (unprivilegierter
-Port). Damit braucht der gesamte Branch nur diesen einen Port nach außen; alle
-Service-Ports darunter sind ephemer.
-
-`dev.sh` nutzt portless auf zwei Arten:
-
-1. **Alias auf festen Port** — Keycloak läuft im Compose-Container auf dem
-   hash-derivierten Host-Port `${KEYCLOAK_PORT}`. `portless alias auth.<slug>
-   <KEYCLOAK_PORT>` mappt den Branch-Hostnamen auf diesen bestehenden Port.
-   Der Port muss vorab feststehen (portless aliast nur auf einen *bereits*
-   gebundenen Port) und aus dem Slug deterministisch sein, damit parallele
-   Worktrees nicht kollidieren. Gleiches gilt für Postgres, das als rohes TCP
-   gar nicht über portless läuft, sondern direkt via `localhost:${POSTGRES_PORT}`
-   in `DATABASE_URL` angesprochen wird.
-2. **Prozess mit ephemerem Port** — `portless <hostname> <command>` startet einen
-   Prozess, injiziert eine freie `PORT`-Env-Var, liest den tatsächlichen Port aus
-   und routet den Hostnamen dorthin. Die Spring-Backends binden über
-   `server.port: ${PORT:8080}` (siehe `application.yml`), Vite respektiert `PORT`
-   ebenso. Deshalb `unset SPRING_PROFILES_ACTIVE` in `dev-env.sh`: das `dev`-Profil
-   würde sonst mit seinem fixen Port die portless-Zuweisung überschreiben.
-
-Branch-Isolation entsteht durch zwei zusammenwirkende Mechanismen:
-
-- **`dev-env.sh`** leitet aus dem Branch-Slug per `cksum` deterministische
-  Host-Ports (Postgres/Keycloak) und den `COMPOSE_PROJECT_NAME` ab → zwei Branches
-  kollidieren weder bei Container-Ports noch bei Compose-Projekten.
-- **portless-Hostnamen** tragen den Slug (`app.<slug>.localhost`, …) → die
-  Browser-/Backend-URLs sind pro Branch eindeutig, inklusive `ISSUER_URI`,
-  `CORS_ALLOWED_ORIGINS` und Keycloak-`redirect_uris` (von `keycloak-config-cli`
-  pro Slug gesetzt).
-
-## Testuser (Realm: miravelo)
-
-| User       | Passwort | Rollen          |
-|------------|----------|-----------------|
-| alice      | test     | CUSTOMER        |
-| bob        | test     | CUSTOMER        |
-| shopkeeper | test     | CUSTOMER, ADMIN |
+Pro Branch entstehen eigene URLs (`http://app.<slug>.localhost:1355`, …) und ein
+eigener Stack auf hash-derivierten Ports. Wie das funktioniert (Routing,
+Branch-Isolation, Ansatz-Vergleich, Testuser) steht in
+[docs/how-to/portless-parallel-development.md](../docs/how-to/portless-parallel-development.md).
 
 ## Verzeichnisstruktur
 
@@ -94,62 +30,6 @@ stack/
 ├── keycloak/       # Realm-Konfiguration (keycloak-config-cli)
 └── docker-compose.yml
 ```
-
-## Ansatz-Vergleich: warum Pro-Branch-Stack?
-
-Der hier gewählte Ansatz — **ein eigener Stack (Postgres + Keycloak) *und* alle
-Services pro Branch** — ist eine bewusste Abwägung zwischen Parität, Isolation
-und Ressourcenverbrauch. Zwei naheliegende Alternativen:
-
-| Kriterium         | **A: Pro-Branch-Stack** (gewählt) | **B: Stackless** (H2 + no-secure) | **C: Geteilter Stack** (Infra auf main, Branch nur FE/BE) |
-|-------------------|-----------------------------------|-----------------------------------|-----------------------------------------------------------|
-| Prod-Parität DB   | ✅ echtes Postgres                 | ❌ H2 ≠ Postgres                   | ✅ echtes Postgres                                         |
-| Prod-Parität Auth | ✅ echtes Keycloak/OIDC            | ❌ Security abgeschaltet           | ✅ echtes Keycloak/OIDC                                    |
-| Branch-Isolation  | ✅ vollständig                     | ✅ (nichts geteilt)                | ❌ geteilte DB- & Realm-State                              |
-| Ressourcen        | ❌ 2 Container + JVMs je Branch    | ✅ minimal                         | 🟡 1× Infra gesamt + JVMs je Branch                       |
-| Startzeit/Branch  | ❌ Keycloak-Health ~60 s           | ✅ Sekunden                        | ✅ nur FE/BE starten                                       |
-| Wartungsaufwand   | 🟡 mehr bewegliche Teile          | ❌ separates no-secure-Profil      | 🟡 Wildcard-Realm + Migrations-Disziplin                  |
-
-**B: Stackless (H2 + no-secure-Profil) — keine Parität.**
-Schnellster Start, kein Docker. Aber das Projekt steht und fällt mit genau den
-Teilen, die B wegabstrahiert:
-
-- Das Schema wird per **Flyway** angelegt, Hibernate läuft mit
-  `ddl-auto: validate` gegen Postgres-geschriebenes DDL (`UUID`,
-  `DOUBLE PRECISION`, `TIMESTAMP`). Unter H2 müsste man entweder H2-kompatible
-  Migrations pflegen oder `validate` aufgeben — beides untergräbt den Sinn der
-  Migration-Tests.
-- Es gibt **kein** no-secure-Profil; `application.yml` verlangt ein echtes
-  `ISSUER_URI`. Ein solches Profil müsste man bauen und parallel zur echten
-  `SecurityConfig` (Rollen `CUSTOMER`/`ADMIN`, JWT, CORS) pflegen — es driftet
-  garantiert weg, und genau dort sitzen die interessanten Bugs.
-
-Fazit: B taugt für reine Domain-/Unit-Arbeit (dafür gibt es bereits Tests),
-nicht für lokales Verifizieren von Auth- und Persistenz-Verhalten. Da dieses
-Repo u.a. einen Keycloak-Spike beherbergt, wäre fehlende Parität hier besonders
-schädlich.
-
-**C: Geteilter Stack (Infra einmalig, Branch startet nur FE/BE).**
-Behält die Parität von A und spart die meisten Ressourcen (ein Postgres, ein
-Keycloak statt n×2 Containern; Branches starten ohne Keycloak-Wartezeit). Der
-Preis ist der Verlust der Isolation — und Isolation ist der eigentliche Zweck
-des Parallel-Dev-Setups:
-
-- **Geteilte DB:** Branches überschreiben sich gegenseitig Daten. Schlimmer:
-  Flyway-Migrations divergieren pro Branch. Fügt ein Branch `V2` hinzu, migriert
-  er die gemeinsame DB und bricht `validate` auf main/anderen Branches.
-- **Geteilter Realm:** `keycloak-config-cli` setzt `redirect_uris`/`web-origins`
-  heute pro Slug. Bei geteiltem Keycloak bräuchte man Wildcard-Origins für alle
-  Branch-Hostnamen, und Realm-Änderungen eines Branches treffen sofort alle.
-
-C ist eine sinnvolle **Opt-in-Optimierung**, wenn der Ressourcendruck hoch ist
-*und* Branches selten Schema oder Realm anfassen. Als Default verlöre man genau
-die Kollisionsfreiheit, die A garantiert.
-
-**Fazit:** A ist richtig, solange nur wenige Worktrees gleichzeitig laufen und
-Korrektheit bei Auth + DB-Migrationen zählt (beides Kernthemen dieses Repos). Der
-Ressourcen-Nachteil ließe sich später durch ein optionales C-Mode-Flag
-abfedern, ohne A als sicheren Default aufzugeben.
 
 ## Lokaler Single-Origin-Mode (nginx, ohne portless)
 
@@ -174,7 +54,7 @@ Routing (alles unter einer Herkunft `http://localhost:8080`):
 |------------------------------|---------------------------------------|
 | `/`                          | Frontend (Vite, Host `:5173`)         |
 | `/api/...`                   | shop-backend (Host `:8081`)           |
-| `/auth/realms/miravelo`        | Keycloak (Realm, Issuer)              |
+| `/auth/realms/miravelo`      | Keycloak (Realm, Issuer)              |
 | `/auth/admin`                | Keycloak Admin (admin/admin)          |
 
 Keycloak ist zusätzlich direkt unter `http://localhost:8088/auth` erreichbar


### PR DESCRIPTION
## Summary

Migrates the portless parallel-development documentation into a dedicated, English how-to guide and slims down the overlapping content elsewhere.

- Adds `docs/how-to/portless-parallel-development.md` — full English guide covering quick start, entry points, how portless works, branch isolation, and the A/B/C approach comparison.
- Trims `stack/README.md` to a short portless intro that links to the new guide (keeps single-origin/nginx mode).
- Replaces the German parallel-dev section in `CLAUDE.md` with a concise two-mode summary linking to the guide.
- Adds a portless callout in `README.md`; minor wording tidy-ups.

## Review notes

One inline finding was posted: the Keycloak Admin URL in the new guide is missing the `:1355` portless port (carried over verbatim from the old README).

The unrelated `scripts/` lockfile changes (`yarn.lock` reformat + new `package-lock.json`) were intentionally left out of this docs PR.