### PR TITLE
fix(portless): correct parallel-dev docs, proxy lifecycle, and profile

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -1,30 +1,30 @@
 # Local Kubernetes Setup with Minikube, Helm, Traefik and CNPG
 
-Dieser Setup läuft komplett hinter Traefik. Zugriff erfolgt über:
+This setup runs entirely behind Traefik. Access goes through:
 
 - Frontend: `http://localhost:8080/`
 - Shop Backend: `http://localhost:8080/api/...`
 - Warehouse Backend: `http://localhost:8080/warehouse/...`
 - Delivery Backend: `http://localhost:8080/delivery/...`
-- Keycloak: `http://localhost:8080/auth/` (Admin-Konsole: `/auth/admin`, `admin` / `admin`)
+- Keycloak: `http://localhost:8080/auth/` (admin console: `/auth/admin`, `admin` / `admin`)
 
-## Authentifizierung (Keycloak)
+## Authentication (Keycloak)
 
-Keycloak läuft als eigener Chart **im Cluster** (`infrastructure/keycloak`) hinter Traefik unter
-`/auth`. Der `miravelo`-Realm wird per `keycloak-config-cli` (Helm post-install Hook) importiert und
-legt die Test-User `alice`, `bob` und `shopkeeper` (Passwort `test`) an.
+Keycloak runs as its own chart **inside the cluster** (`infrastructure/keycloak`) behind Traefik under
+`/auth`. The `miravelo` realm is imported via `keycloak-config-cli` (Helm post-install hook) and
+creates the test users `alice`, `bob` and `shopkeeper` (password `test`).
 
-Die Services sind passend konfiguriert:
+The services are configured accordingly:
 
 - Frontend (`shop-frontend/values.local.yaml`): `env.KEYCLOAK_URL` / `KEYCLOAK_REALM` / `KEYCLOAK_CLIENT_ID`
 - Backend (`shop-backend/values.local.yaml`):
-  - `application.security.issuer-uri` → browser-seitige URL (`http://localhost:8080/auth/realms/miravelo`),
-    muss mit dem `iss`-Claim der Tokens übereinstimmen.
-  - `application.security.jwk-set-uri` → clusterinterner Service
-    (`http://keycloak:8080/auth/realms/miravelo/protocol/openid-connect/certs`). Wird als
-    `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI` ins Deployment gemappt, da der
-    browser-seitige `issuer-uri` aus dem Pod heraus nicht erreichbar ist. Die `iss`-Prüfung läuft
-    weiterhin gegen den `issuer-uri`.
+  - `application.security.issuer-uri` → browser-side URL (`http://localhost:8080/auth/realms/miravelo`),
+    must match the `iss` claim of the tokens.
+  - `application.security.jwk-set-uri` → cluster-internal service
+    (`http://keycloak:8080/auth/realms/miravelo/protocol/openid-connect/certs`). Mapped into the
+    deployment as `SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_JWK_SET_URI`, because the browser-side
+    `issuer-uri` is not reachable from inside the pod. The `iss` check still runs against the
+    `issuer-uri`.
 
 ## Prerequisites
 
@@ -33,7 +33,7 @@ Die Services sind passend konfiguriert:
 - kubectl
 - Helm
 
-## 1) Minikube starten
+## 1) Start Minikube
 
 ```bash
 minikube config set driver docker
@@ -41,7 +41,7 @@ minikube start -p miravelo-example
 kubectl config use-context miravelo-example
 ```
 
-## 2) Projekt bauen und Images in Minikube bauen
+## 2) Build the project and build images in Minikube
 
 ```bash
 cd ..
@@ -54,7 +54,7 @@ minikube -p miravelo-example image build -t warehouse-backend:local -f services/
 minikube -p miravelo-example image build -t shop-frontend:local -f services/shop/shop-frontend/Dockerfile .
 ```
 
-## 3) Infrastruktur deployen (CNPG Operator -> Postgres -> Traefik -> Keycloak)
+## 3) Deploy the infrastructure (CNPG operator -> Postgres -> Traefik -> Keycloak)
 
 ```bash
 helm dependency build ./infrastructure/cnpg-operator
@@ -76,13 +76,13 @@ helm upgrade --install traefik ./infrastructure/traefik \
   --create-namespace \
   -f infrastructure/traefik/values.yaml 
 
-# Keycloak (Release-Name "keycloak", damit der Service clusterintern als
-# http://keycloak:8080 erreichbar ist – darauf zeigt die backend jwk-set-uri).
+# Keycloak (release name "keycloak", so the service is reachable cluster-internally
+# as http://keycloak:8080 — the backend jwk-set-uri points there).
 helm upgrade --install keycloak ./infrastructure/keycloak \
   --namespace miravelo-local
 ```
 
-## 4) Services deployen
+## 4) Deploy the services
 
 ```bash
 helm upgrade --install shop-backend ./shop-backend \
@@ -102,15 +102,15 @@ helm upgrade --install shop-frontend ./shop-frontend \
   -f ./shop-frontend/values.local.yaml
 ```
 
-## 5) Zugriff aktivieren
+## 5) Enable access
 
-Traefik läuft als `LoadBalancer` auf Port `8080` (Services routen intern per Traefik IngressRoute):
+Traefik runs as a `LoadBalancer` on port `8080` (services route internally via Traefik IngressRoute):
 
 ```bash
 minikube tunnel -p miravelo-example
 ```
 
-## 6) Routing testen
+## 6) Test the routing
 
 ```bash
 curl http://localhost:8080/
@@ -119,7 +119,7 @@ curl http://localhost:8080/warehouse/api/articles
 curl http://localhost:8080/delivery/api/articles
 ```
 
-## Nützliche Befehle
+## Useful commands
 
 ```bash
 minikube list profiles

--- a/docs/how-to/portless-parallel-development.md
+++ b/docs/how-to/portless-parallel-development.md
@@ -19,6 +19,16 @@ anything getting in each other's way.
 > *single* branch, the simpler single-origin mode (nginx on `:8080`) is the better
 > fit — see [`stack/README.md`](../../stack/README.md).
 
+## ✅ Prerequisites
+
+- **Node.js 24+** — required by portless (`engines.node >=24`); older versions fail to
+  run it.
+- **Docker or Podman** with **Compose v2** (the `docker compose` CLI) for the per-branch
+  Postgres + Keycloak stack. `dev:down`'s orphan cleanup additionally needs **`jq`**.
+- **Java 21** — for the Gradle/Spring backends.
+- Tested on **macOS and Linux**. Windows is unverified here (portless declares Windows
+  support, but this flow has not been validated on it).
+
 ## 🚀 Quick start
 
 ```bash
@@ -30,7 +40,9 @@ npm --prefix scripts run dev:down   # stop Compose (portless processes via Ctrl-
 `dev:down` stops the current branch's stack and additionally cleans up orphaned
 `miravelo-*` stacks whose Compose file no longer exists (e.g. deleted worktrees).
 Stacks of live worktrees (Compose file still present) keep running — that is exactly
-what makes parallel dev possible.
+what makes parallel dev possible. The shared portless proxy on `:1355` is stopped
+automatically only when the *last* worktree's stack is torn down; while any branch stack
+is still up, the proxy keeps running so the other branches keep routing.
 
 ## 🌐 Entry points
 
@@ -45,7 +57,7 @@ e.g. `spike-keycloak-portless`).
 | `http://delivery.${BRANCH_SLUG}.localhost:1355`  | delivery-backend             |
 | `http://warehouse.${BRANCH_SLUG}.localhost:1355` | warehouse-backend            |
 | `http://auth.${BRANCH_SLUG}.localhost:1355`      | Keycloak                     |
-| `http://auth.${BRANCH_SLUG}.localhost/admin`     | Keycloak Admin (admin/admin) |
+| `http://auth.${BRANCH_SLUG}.localhost:1355/admin`| Keycloak Admin (admin/admin) |
 
 Postgres is not reachable through portless (no HTTP) — connect directly on
 `localhost:${POSTGRES_PORT}` (see the `dev-env.sh` output on startup).
@@ -62,9 +74,14 @@ Postgres is not reachable through portless (no HTTP) — connect directly on
 
 [portless](https://github.com/vercel-labs/portless) is a local reverse proxy that
 occupies **one** port (`1355`) and routes to local processes based on the host name.
-`*.localhost` resolves automatically to `127.0.0.1` on macOS/Linux — no editing of
-`/etc/hosts`, no TLS, no sudo (unprivileged port). That way the entire branch only
-needs this single port facing outward; all service ports underneath are ephemeral.
+`*.localhost` resolves to `127.0.0.1` automatically in Chromium-based browsers
+(Chrome/Edge) and Firefox — no editing of `/etc/hosts`. **Safari** uses the system
+resolver and may not resolve `*.localhost`; if branch URLs don't load there, run
+`npm --prefix scripts exec -- portless hosts sync` once (it writes `/etc/hosts` and may
+prompt for sudo). This setup deliberately runs portless with `--no-tls` on the
+unprivileged port `1355`, so it needs no TLS and no sudo — portless otherwise defaults
+to HTTPS on `:443`, which *does* elevate. That way the entire branch only needs this
+single port facing outward; all service ports underneath are ephemeral.
 
 `dev.sh` uses portless in two ways:
 

--- a/scripts/dev-down.sh
+++ b/scripts/dev-down.sh
@@ -47,3 +47,19 @@ while IFS=$'\t' read -r name config_files; do
   docker compose -p "$name" down --remove-orphans
   remove_alias "${name#miravelo-}"
 done < <(docker compose ls -a --format json | jq -r '.[] | [.Name, .ConfigFiles] | @tsv')
+
+# 3) Reap any dev-server routes leaked by a SIGKILLed session. Safe for parallel
+#    worktrees: prune only touches orphans whose owning CLI process is dead.
+if [[ -x "$PORTLESS" ]]; then
+  "$PORTLESS" prune >/dev/null 2>&1 || true
+fi
+
+# 4) If no miravelo-* stacks remain, this was the last live worktree — stop the
+#    shared portless proxy so it doesn't linger on :${PORTLESS_PORT}. Otherwise
+#    leave it running so other branches keep routing. --port is required because
+#    the proxy runs on a non-default port (proxy stop defaults to the standard one).
+remaining="$(docker compose ls -a --format json | jq -r '.[].Name' | grep -c '^miravelo-' || true)"
+if [[ "${remaining:-0}" -eq 0 && -x "$PORTLESS" ]]; then
+  echo "Last miravelo-* stack torn down — stopping shared portless proxy on :${PORTLESS_PORT}."
+  "$PORTLESS" proxy stop --port "${PORTLESS_PORT}" >/dev/null 2>&1 || true
+fi

--- a/scripts/dev-env.sh
+++ b/scripts/dev-env.sh
@@ -20,6 +20,11 @@ export COMPOSE_PROJECT_NAME="miravelo-${BRANCH_SLUG}"
 
 export PORTLESS_HTTPS=0
 export PORTLESS_PORT=1355
+# portless writes *.localhost entries to /etc/hosts on the proxy by default,
+# which needs root and would trigger a sudo prompt on TTY-less runs — at odds
+# with this setup's no-sudo design (--no-tls on an unprivileged port). Keep it
+# off; Safari users who need .localhost resolution run `portless hosts sync`.
+export PORTLESS_SYNC_HOSTS=0
 PORTLESS_BASE_SUFFIX=".${BRANCH_SLUG}.localhost:${PORTLESS_PORT}"
 
 export ISSUER_URI="http://auth${PORTLESS_BASE_SUFFIX}/realms/miravelo"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -40,6 +40,11 @@ docker compose -f "$REPO_ROOT/stack/docker-compose.yml" up -d --wait
 # invocations). --no-tls + the unprivileged port from $PORTLESS_PORT.
 "$PORTLESS" proxy start --no-tls --port "${PORTLESS_PORT}" >/dev/null 2>&1 || true
 
+# Reap routes/dev-servers leaked by a previously SIGKILLed/crashed session before
+# this branch registers its own. prune only touches orphans whose owning CLI is
+# already dead, so live parallel worktrees are unaffected.
+"$PORTLESS" prune >/dev/null 2>&1 || true
+
 "$PORTLESS" alias "auth.${BRANCH_SLUG}" "${KEYCLOAK_PORT}"
 
 pids=()

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -7,6 +7,9 @@
     "dev": "./dev.sh",
     "dev:down": "./dev-down.sh"
   },
+  "engines": {
+    "node": ">=24"
+  },
   "dependencies": {
     "portless": "0.14.0"
   }

--- a/stack/README.md
+++ b/stack/README.md
@@ -1,73 +1,72 @@
 # Stack
 
-Dev-Infrastruktur (Postgres + Keycloak) für zwei Setups aus **einer**
+Dev infrastructure (Postgres + Keycloak) for two setups from **one**
 `docker-compose.yml`:
 
-- **Portless (parallel):** pro Checkout ein eigener Stack, Routing zu lokalen
-  Backend-/Frontend-Prozessen via [portless](https://github.com/vercel-labs/portless).
-  Mehrere Branches laufen kollisionsfrei parallel.
-  → Vollständige Anleitung: [docs/how-to/portless-parallel-development.md](../docs/how-to/portless-parallel-development.md).
-- **Lokal (single-origin):** ein nginx auf `:8080` als einziger Entry-Point, der
-  Frontend, `/api` und Keycloak (`/auth`) unter einer Herkunft bündelt (siehe unten).
+- **Portless (parallel):** one dedicated stack per checkout, routing to local
+  backend/frontend processes via [portless](https://github.com/vercel-labs/portless).
+  Multiple branches run side by side without collisions.
+  → Full guide: [docs/how-to/portless-parallel-development.md](../docs/how-to/portless-parallel-development.md).
+- **Local (single-origin):** a single nginx on `:8080` as the only entry point,
+  bundling frontend, `/api` and Keycloak (`/auth`) under one origin (see below).
 
 ## Start — Portless (parallel)
 
 ```bash
-npm --prefix scripts install        # einmalig pro Checkout: installiert portless
-npm --prefix scripts run dev        # Stack hoch + alle Backends/Frontend via portless
-npm --prefix scripts run dev:down   # Compose stoppen (portless-Prozesse via Ctrl-C in dev)
+npm --prefix scripts install        # once per checkout: installs portless
+npm --prefix scripts run dev        # bring up the stack + all backends/frontend via portless
+npm --prefix scripts run dev:down   # stop Compose (portless processes via Ctrl-C in dev)
 ```
 
-Pro Branch entstehen eigene URLs (`http://app.<slug>.localhost:1355`, …) und ein
-eigener Stack auf hash-derivierten Ports. Wie das funktioniert (Routing,
-Branch-Isolation, Ansatz-Vergleich, Testuser) steht in
+Each branch gets its own URLs (`http://app.<slug>.localhost:1355`, …) and its own
+stack on hash-derived ports. How this works (routing, branch isolation, approach
+comparison, test users) is documented in
 [docs/how-to/portless-parallel-development.md](../docs/how-to/portless-parallel-development.md).
 
-## Verzeichnisstruktur
+## Directory structure
 
 ```
 stack/
-├── keycloak/       # Realm-Konfiguration (keycloak-config-cli)
+├── keycloak/       # Realm configuration (keycloak-config-cli)
 └── docker-compose.yml
 ```
 
-## Lokaler Single-Origin-Mode (nginx, ohne portless)
+## Local single-origin mode (nginx, without portless)
 
-Wer nicht parallel arbeitet, startet die Infra inkl. **nginx** und die Services
-direkt — ohne `dev-env.sh`. Backend und Frontend laufen auf dem Host (z.B. über
-die IntelliJ-Run-Configs), nginx proxyt sie zusammen mit Keycloak unter `:8080`:
+If you don't work in parallel, start the infra including **nginx** and the services
+directly — without `dev-env.sh`. Backend and frontend run on the host (e.g. via the
+IntelliJ run configs); nginx proxies them together with Keycloak under `:8080`:
 
 ```bash
 cd stack && docker compose --profile solo up -d   # Postgres + Keycloak + nginx
 SPRING_PROFILES_ACTIVE=dev ./gradlew :services:shop:shop-backend:bootRun
-npm --prefix services/shop/shop-frontend run dev  # Vite auf :5173
-# danach: http://localhost:8080 öffnen
+npm --prefix services/shop/shop-frontend run dev  # Vite on :5173
+# then open: http://localhost:8080
 ```
 
-> Wichtig: **`--profile solo`** — ohne das Profil startet nginx nicht (so bleibt
-> es im portless-Modus aus). App öffnen unter **`http://localhost:8080`**, nicht
-> `:5173` und nicht direkt auf Keycloak.
+> Important: **`--profile solo`** — without the profile nginx does not start (so it
+> stays off in portless mode). Open the app at **`http://localhost:8080`**, not
+> `:5173` and not directly on Keycloak.
 
-Routing (alles unter einer Herkunft `http://localhost:8080`):
+Routing (everything under one origin `http://localhost:8080`):
 
-| Pfad                         | Ziel                                  |
+| Path                         | Target                                |
 |------------------------------|---------------------------------------|
-| `/`                          | Frontend (Vite, Host `:5173`)         |
-| `/api/...`                   | shop-backend (Host `:8081`)           |
-| `/auth/realms/miravelo`      | Keycloak (Realm, Issuer)              |
+| `/`                          | Frontend (Vite, host `:5173`)         |
+| `/api/...`                   | shop-backend (host `:8081`)           |
+| `/auth/realms/miravelo`      | Keycloak (realm, issuer)              |
 | `/auth/admin`                | Keycloak Admin (admin/admin)          |
 
-Keycloak ist zusätzlich direkt unter `http://localhost:8088/auth` erreichbar
-(eigener Host-Port, da nginx `:8080` belegt). Login als `alice`/`test` läuft über
-die App auf `:8080`.
+Keycloak is additionally reachable directly at `http://localhost:8088/auth` (its own
+host port, since nginx occupies `:8080`). Logging in as `alice`/`test` goes through
+the app on `:8080`.
 
-Ohne gesetzte Env-Vars greifen die Defaults der `docker-compose.yml` (Projekt
-`miravelo-local`, Postgres `5432`, Keycloak-Admin `8088`, nginx `8080`,
+Without env vars set, the `docker-compose.yml` defaults apply (project
+`miravelo-local`, Postgres `5432`, Keycloak admin `8088`, nginx `8080`,
 `KC_HOSTNAME=http://localhost:8080/auth`, `KC_HTTP_RELATIVE_PATH=/auth`,
-Redirect/Origin `http://localhost:8080`) — passend zu `application-dev.yml`
+redirect/origin `http://localhost:8080`) — matching `application-dev.yml`
 (`ISSUER_URI=http://localhost:8080/auth/realms/miravelo`, shop `:8081`).
 
-`dev.sh` überschreibt dieselben Variablen via `dev-env.sh` mit den
-branch-spezifischen portless-Werten (Keycloak unter Root-Pfad `/`, eigene
-Hostnamen statt `/auth`), und startet **ohne** `--profile solo`, sodass nginx
-dort nie läuft.
+`dev.sh` overrides the same variables via `dev-env.sh` with the branch-specific
+portless values (Keycloak under root path `/`, dedicated host names instead of
+`/auth`), and starts **without** `--profile solo`, so nginx never runs there.

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -77,13 +77,13 @@ services:
         condition: service_healthy
     restart: "no"
 
-  # Single entry point for local dev — only started with `--profile local`, so it
+  # Single entry point for local dev — only started with `--profile solo`, so it
   # never runs in the portless setup (which has its own reverse proxy). Proxies
   # the frontend (vite) and backend running on the host, plus keycloak in-compose.
   nginx:
     image: nginx:alpine
     container_name: miravelo-${BRANCH_SLUG:-local}-nginx
-    profiles: ["local"]
+    profiles: ["solo"]
     ports:
       - "8080:80"
     volumes:


### PR DESCRIPTION
## Why

Best-practice pass over the portless parallel-dev setup, preparing it to be published as a public example / blog post. A multi-agent review of the integration found it solid overall but flagged a few publish-blocking documentation bugs and a couple of lifecycle gaps; this PR addresses them.

## What changed

**Proxy lifecycle (`scripts/dev.sh`, `scripts/dev-down.sh`)**
- `prune` routes/dev-servers leaked by a previously SIGKILLed session (safe for parallel worktrees — only orphans whose owning CLI is already dead are touched).
- Stop the shared `:1355` proxy **only when the last worktree's stack is torn down**; while any branch stack is still up, the proxy keeps running so the other branches keep routing. `proxy stop --port 1355` is used because the proxy runs on a non-default port.

**Single-origin profile (`stack/docker-compose.yml`)**
- nginx was gated on `profiles: ["local"]` while every doc said `--profile solo`, so `docker compose --profile solo up` never started nginx and `http://localhost:8080` was dead. Standardized on `solo` (verified: nginx absent by default, present under `--profile solo`).

**Docs (`docs/how-to/portless-parallel-development.md`)**
- Fix the Keycloak Admin URL (was missing `:1355`, so it resolved to port 80 and failed).
- Correct the `.localhost` resolution note: auto-resolves in Chromium/Firefox; **Safari** needs `portless hosts sync`. Credit the no-sudo/no-TLS behavior to the deliberate `--no-tls --port 1355` choice.
- Add a **Prerequisites** section (Node.js 24+, Docker/Podman + Compose v2, jq, Java 21; macOS/Linux).
- Document that the shared proxy is stopped only on last teardown.

**Misc**
- `scripts/dev-env.sh`: `PORTLESS_SYNC_HOSTS=0` to keep TTY-less runs sudo-free (portless otherwise auto-writes `/etc/hosts`, which needs root).
- `scripts/package.json`: declare `engines.node >=24` (hard portless requirement) so a wrong Node version surfaces at install time.
- Translate `stack/README.md` (fully) and `charts/README.md` to English.

## Verification

- `bash -n` passes on all three dev scripts.
- `docker compose config --services` confirms nginx is absent by default and present under `--profile solo`.
- `prune`, `proxy stop`, `alias`, `hosts sync` and `PORTLESS_SYNC_HOSTS=0` confirmed against the installed `portless@0.14.0` CLI.
- `scripts/package.json` is valid JSON with `engines.node = ">=24"`.
- No German remains in the translated READMEs; profile naming is consistent across compose/README/CLAUDE.md.
- No JVM/TS source changed, so the Gradle/Cypress suites are unaffected.

> Not in this PR (follow-up candidates from the review): hash-port collision detection, `jq` preflight in teardown, a routing diagram + troubleshooting section.